### PR TITLE
fixed error where user avatar updates with every refresh

### DIFF
--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -16,7 +16,11 @@
             <p class="req-total"><%= format_price(booking.item.daily_rate) %> x <%= (booking.end_date - booking.start_date).to_i  %> = <%= format_price(booking.item.daily_rate * (booking.end_date - booking.start_date).to_i) %> </p>
           </div>
           <div class="item-owner-details">
-            <img class="user-prof-pic" src="https://source.unsplash.com/random?person" alt="/user">
+            <% if booking.item.user.avatar.present? %>
+              <%= cl_image_tag(booking.item.user.avatar.key, class: "user-img rounded-circle") %>
+            <% else %>
+              <img class="user-prof-pic" src="https://source.unsplash.com/random/?person" alt="user-img">
+            <% end %>
             <p class="user-name"><%= booking.item.user.username %></p>
           </div>
         </div>


### PR DESCRIPTION
This only works for users with profile pictures already on their profile. 
In order for this to work universally, we need to add user profile pictures to our seeds (its already in the sign up model).